### PR TITLE
Add low-cost chunked sitemap routes.

### DIFF
--- a/apps/shadcnpreset/app/robots.ts
+++ b/apps/shadcnpreset/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next"
+
+import { siteConfig } from "@/lib/config"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: [`${siteConfig.url}/sitemap.xml`],
+  }
+}

--- a/apps/shadcnpreset/app/sitemap.xml/route.ts
+++ b/apps/shadcnpreset/app/sitemap.xml/route.ts
@@ -1,0 +1,30 @@
+import { siteConfig } from "@/lib/config"
+import {
+  buildSitemapIndexXml,
+  getPresetSitemapChunkCount,
+} from "@/lib/sitemap"
+
+export const revalidate = 60 * 60 * 24
+
+export function GET() {
+  const nowIso = new Date().toISOString()
+  const presetChunkCount = getPresetSitemapChunkCount()
+
+  const entries = [
+    {
+      loc: `${siteConfig.url}/sitemaps/static.xml`,
+      lastmod: nowIso,
+    },
+    ...Array.from({ length: presetChunkCount }, (_, chunk) => ({
+      loc: `${siteConfig.url}/sitemaps/presets/${chunk}`,
+      lastmod: nowIso,
+    })),
+  ]
+
+  return new Response(buildSitemapIndexXml(entries), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  })
+}

--- a/apps/shadcnpreset/app/sitemap.xml/route.ts
+++ b/apps/shadcnpreset/app/sitemap.xml/route.ts
@@ -4,7 +4,7 @@ import {
   getPresetSitemapChunkCount,
 } from "@/lib/sitemap"
 
-export const revalidate = 60 * 60 * 24
+export const revalidate = 86_400
 
 export function GET() {
   const nowIso = new Date().toISOString()

--- a/apps/shadcnpreset/app/sitemaps/presets/[chunk]/route.ts
+++ b/apps/shadcnpreset/app/sitemaps/presets/[chunk]/route.ts
@@ -1,0 +1,43 @@
+import { siteConfig } from "@/lib/config"
+import {
+  buildUrlSetXml,
+  getPresetSitemapChunkCount,
+  getPresetSitemapEntriesForChunk,
+} from "@/lib/sitemap"
+
+export const revalidate = 60 * 60 * 24
+
+type PresetSitemapRouteProps = {
+  params: Promise<{
+    chunk: string
+  }>
+}
+
+function notFoundResponse() {
+  return new Response("Not found", { status: 404 })
+}
+
+export async function GET(_request: Request, { params }: PresetSitemapRouteProps) {
+  const { chunk } = await params
+  const chunkNumber = Number.parseInt(chunk, 10)
+
+  if (Number.isNaN(chunkNumber) || chunkNumber < 0) {
+    return notFoundResponse()
+  }
+
+  if (chunkNumber >= getPresetSitemapChunkCount()) {
+    return notFoundResponse()
+  }
+
+  const entries = getPresetSitemapEntriesForChunk({
+    chunk: chunkNumber,
+    baseUrl: siteConfig.url,
+  })
+
+  return new Response(buildUrlSetXml(entries), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  })
+}

--- a/apps/shadcnpreset/app/sitemaps/presets/[chunk]/route.ts
+++ b/apps/shadcnpreset/app/sitemaps/presets/[chunk]/route.ts
@@ -5,7 +5,7 @@ import {
   getPresetSitemapEntriesForChunk,
 } from "@/lib/sitemap"
 
-export const revalidate = 60 * 60 * 24
+export const revalidate = 86_400
 
 type PresetSitemapRouteProps = {
   params: Promise<{

--- a/apps/shadcnpreset/app/sitemaps/static.xml/route.ts
+++ b/apps/shadcnpreset/app/sitemaps/static.xml/route.ts
@@ -1,0 +1,22 @@
+import { siteConfig } from "@/lib/config"
+import { buildUrlSetXml } from "@/lib/sitemap"
+
+export const revalidate = 60 * 60 * 24
+
+const STATIC_PATHS = ["/", "/community", "/assistant", "/my-presets"] as const
+
+export function GET() {
+  const nowIso = new Date().toISOString()
+
+  const entries = STATIC_PATHS.map((path) => ({
+    loc: `${siteConfig.url}${path}`,
+    lastmod: nowIso,
+  }))
+
+  return new Response(buildUrlSetXml(entries), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  })
+}

--- a/apps/shadcnpreset/app/sitemaps/static.xml/route.ts
+++ b/apps/shadcnpreset/app/sitemaps/static.xml/route.ts
@@ -1,7 +1,7 @@
 import { siteConfig } from "@/lib/config"
 import { buildUrlSetXml } from "@/lib/sitemap"
 
-export const revalidate = 60 * 60 * 24
+export const revalidate = 86_400
 
 const STATIC_PATHS = ["/", "/community", "/assistant", "/my-presets"] as const
 

--- a/apps/shadcnpreset/lib/sitemap.ts
+++ b/apps/shadcnpreset/lib/sitemap.ts
@@ -1,0 +1,66 @@
+import { getPresetPage, PRESET_TOTAL_COMBINATIONS } from "@/lib/preset-catalog"
+
+export const SITEMAP_MAX_URLS = 50_000
+
+type SitemapEntry = {
+  loc: string
+  lastmod?: string
+}
+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>'
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;")
+}
+
+export function getPresetSitemapChunkCount() {
+  return Math.ceil(PRESET_TOTAL_COMBINATIONS / SITEMAP_MAX_URLS)
+}
+
+export function getPresetSitemapEntriesForChunk({
+  chunk,
+  baseUrl,
+}: {
+  chunk: number
+  baseUrl: string
+}): SitemapEntry[] {
+  const page = chunk + 1
+  const presets = getPresetPage(page, SITEMAP_MAX_URLS)
+
+  return presets.map(({ code }) => ({
+    loc: `${baseUrl}/preset/${code}`,
+  }))
+}
+
+export function buildUrlSetXml(entries: SitemapEntry[]) {
+  const urlNodes = entries
+    .map((entry) => {
+      const lastModTag = entry.lastmod
+        ? `<lastmod>${escapeXml(entry.lastmod)}</lastmod>`
+        : ""
+
+      return `<url><loc>${escapeXml(entry.loc)}</loc>${lastModTag}</url>`
+    })
+    .join("")
+
+  return `${XML_DECLARATION}<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urlNodes}</urlset>`
+}
+
+export function buildSitemapIndexXml(entries: SitemapEntry[]) {
+  const sitemapNodes = entries
+    .map((entry) => {
+      const lastModTag = entry.lastmod
+        ? `<lastmod>${escapeXml(entry.lastmod)}</lastmod>`
+        : ""
+
+      return `<sitemap><loc>${escapeXml(entry.loc)}</loc>${lastModTag}</sitemap>`
+    })
+    .join("")
+
+  return `${XML_DECLARATION}<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${sitemapNodes}</sitemapindex>`
+}


### PR DESCRIPTION
Introduce a sitemap index, static sitemap, preset chunk sitemaps, and robots sitemap discovery to support large preset catalogs with cache-friendly generation.

Made-with: Cursor