### PR TITLE
Move community snapshot refresh to offline automation.

### DIFF
--- a/.github/workflows/community-snapshot-refresh.yml
+++ b/.github/workflows/community-snapshot-refresh.yml
@@ -1,0 +1,65 @@
+name: Community Snapshot Refresh
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Maximum preset codes to include in snapshot"
+        required: false
+        default: "2000"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10.33.4
+          run_install: false
+
+      - name: Validate DATABASE_URL secret
+        env:
+          DATABASE_URL: ${{ secrets.SHADCNPRESET_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::Missing SHADCNPRESET_DATABASE_URL repository secret."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh snapshot JSON
+        env:
+          DATABASE_URL: ${{ secrets.SHADCNPRESET_DATABASE_URL }}
+          SNAPSHOT_LIMIT: ${{ github.event.inputs.limit || '2000' }}
+        run: pnpm --filter shadcnpreset refresh:community-snapshot -- "$SNAPSHOT_LIMIT" github-cron
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(shadcnpreset): refresh community snapshot data"
+          title: "chore(shadcnpreset): refresh community snapshot data"
+          body: |
+            Automated community snapshot refresh.
+
+            - Regenerated `apps/shadcnpreset/data/community-presets-snapshot.json`
+            - Source: scheduled GitHub Action
+          branch: automation/community-snapshot-refresh
+          delete-branch: true
+          add-paths: |
+            apps/shadcnpreset/data/community-presets-snapshot.json

--- a/apps/shadcnpreset/.env.example
+++ b/apps/shadcnpreset/.env.example
@@ -24,9 +24,9 @@ OPENAI_API_KEY=
 # OPENAI_ASSISTANT_MODEL=gpt-4o-mini
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
-# Shared secret for the cron refresh endpoint.
-# Vercel Cron sends `Authorization: Bearer <CRON_SECRET>`.
-CRON_SECRET=
+# Used by snapshot refresh scripts/workflows that read vote rankings from Neon
+# and regenerate `data/community-presets-snapshot.json`.
+# DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME
 # Local-only escape hatch: bypass snapshot-first reads and query DB directly
 # (still falls back deterministically if DB fails).
 # LOCAL_DISABLE_COMMUNITY_SNAPSHOT=1

--- a/apps/shadcnpreset/COMMUNITY_SNAPSHOT.md
+++ b/apps/shadcnpreset/COMMUNITY_SNAPSHOT.md
@@ -1,44 +1,46 @@
 # Community Snapshot Architecture
 
-This app uses a snapshot-based flow for community ranking so build/runtime do not depend on live vote queries on every request.
+This app uses a snapshot-based flow for community ranking so runtime does not
+depend on live vote aggregation queries.
 
 ## Goal
 
 - Keep `/community` and community sitemap stable.
 - Avoid hard failures when Neon is down or quota-limited.
 - Keep ranking freshness with scheduled refreshes.
-- Avoid Vercel Blob operation costs.
+- Keep runtime Neon reads at zero for snapshot consumption.
 
 ## Flow
 
-1. Vercel Cron triggers `GET /api/internal/community-snapshot/refresh` daily (Hobby plan limit).
-2. The refresh route queries `preset_votes` in Neon and gets ranked preset codes.
+1. A scheduled GitHub Action runs daily (or manually via `workflow_dispatch`).
+2. The job queries `preset_votes` in Neon and gets ranked preset codes.
 3. Codes are normalized to canonical preset codes.
-4. Snapshot JSON is upserted into a single Neon row (`community_snapshot`).
-5. Consumers read snapshot first:
+4. The job writes `data/community-presets-snapshot.json`.
+5. A PR is opened automatically when the snapshot file changes.
+6. After merge/deploy, consumers read snapshot first:
    - `/community` feed
    - `/sitemaps/community-presets.xml`
    - community membership checks
-6. If snapshot is unavailable, deterministic catalog fallback is used.
+7. If snapshot is unavailable, deterministic catalog fallback is used.
 
 ## Storage
 
-- **Runtime (production):** one row in Neon table `community_snapshot`, cached for up to 1 hour.
-- **Build/offline:** bundled file `data/community-presets-snapshot.json`.
-- **Local refresh script:** can update both Neon row and the bundled JSON file.
+- **Runtime (production):** bundled file `data/community-presets-snapshot.json`.
+- **Refresh job only:** reads `preset_votes` from Neon to regenerate the file.
+- **Local refresh script:** updates the bundled JSON file.
 
 No Vercel Blob is used.
 
 ## Files
 
 - Snapshot service: `lib/community-snapshot.ts`
-- Cron endpoint: `app/api/internal/community-snapshot/refresh/route.ts`
+- Offline refresh workflow: `.github/workflows/community-snapshot-refresh.yml`
 - Local refresh script: `scripts/refresh-community-snapshot.ts`
-- Cron config: `vercel.json`
+- Local shell wrapper: `scripts/refresh-community-snapshot.sh`
 - Community consumer wiring: `lib/community-presets.ts`
 - Feed consumer wiring: `lib/preset-feed.ts`
 - Community sitemap route: `app/sitemaps/community-presets.xml/route.ts`
-- Bundled fallback: `data/community-presets-snapshot.json`
+- Bundled snapshot: `data/community-presets-snapshot.json`
 
 ## Snapshot Format
 
@@ -47,25 +49,19 @@ Stored JSON payload:
 ```json
 {
   "generatedAt": "2026-06-01T07:00:00.000Z",
-  "source": "neon-cron",
+  "source": "github-cron",
   "codes": ["b1FQfCxG4", "b2abc...", "..."]
 }
 ```
 
 Notes:
 - `codes` are canonicalized and deduplicated.
-- `source` is `neon-cron` (cron) or `manual-refresh` (manual trigger).
-
-## Security
-
-Refresh endpoint authorization:
-
-- Required: `Authorization: Bearer <CRON_SECRET>`
+- `source` is `github-cron` (scheduled automation) or `manual-refresh`.
 
 ## Required Environment Variables
 
-- `DATABASE_URL` (Neon votes + snapshot row)
-- `CRON_SECRET` (protect refresh endpoint)
+- `DATABASE_URL` (used by refresh script/workflow to read vote rankings)
+- `SHADCNPRESET_DATABASE_URL` GitHub repository secret (workflow input)
 
 ## Local Development
 
@@ -89,34 +85,31 @@ then still fall back to deterministic catalog ordering if DB is unavailable.
 With `DATABASE_URL` set:
 
 ```bash
-pnpm refresh:community-snapshot
+pnpm --filter shadcnpreset refresh:community-snapshot -- 2000 manual-refresh
 ```
 
-This updates:
-- Neon `community_snapshot` row
-- `data/community-presets-snapshot.json`
+This updates `data/community-presets-snapshot.json`.
 
-### Refresh Snapshot In Production
+### Run Refresh Automation Manually
 
 ```bash
-curl -H "Authorization: Bearer <CRON_SECRET>" \
-  "https://your-domain.com/api/internal/community-snapshot/refresh?limit=2000"
+gh workflow run "Community Snapshot Refresh" -f limit=2000
 ```
 
-Or use:
+### Setup Checklist (GitHub Action)
 
-```bash
-CRON_SECRET="..." ./scripts/refresh-community-snapshot.sh https://your-domain.com 2000
-```
+- Add repository secret `SHADCNPRESET_DATABASE_URL`.
+- Ensure the workflow has permission to open PRs.
+- Merge snapshot refresh PRs as they appear.
 
 ## Failure Behavior
 
-- If refresh fails: existing snapshot row remains; consumers still work.
+- If refresh fails: previous snapshot file remains deployed; consumers still work.
 - If snapshot read fails: deterministic fallback is returned.
-- If Neon is unavailable: only refresh job is impacted; render/build paths remain stable.
+- If Neon is unavailable: refresh job is impacted; runtime pages still render from the deployed snapshot/fallback.
 
 ## Cost Notes
 
-- Cron refresh: one Neon query + one upsert per day.
-- Runtime reads: one cached Neon read per hour at most (not per request).
-- Build: reads bundled JSON only; no Neon required.
+- Refresh automation: Neon reads only during scheduled/manual refresh job.
+- Runtime reads: file-based snapshot only (no Neon `community_snapshot` query path).
+- Build/runtime both can operate without Neon when snapshot file exists.

--- a/apps/shadcnpreset/app/api/internal/community-snapshot/refresh/route.ts
+++ b/apps/shadcnpreset/app/api/internal/community-snapshot/refresh/route.ts
@@ -1,64 +1,13 @@
 import { NextResponse } from "next/server"
 
-import { getCommunityPresetCodes } from "@/lib/community-presets"
-import { writeCommunitySnapshot } from "@/lib/community-snapshot"
-
-function isAuthorized(request: Request) {
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret) {
-    return false
-  }
-
-  const authorization = request.headers.get("authorization")
-  const bearerToken = authorization?.startsWith("Bearer ")
-    ? authorization.slice("Bearer ".length)
-    : null
-  return bearerToken === cronSecret
-}
-
 export async function GET(request: Request) {
-  if (!process.env.CRON_SECRET) {
-    return NextResponse.json(
-      { error: "CRON_SECRET is required for snapshot refresh" },
-      { status: 500 }
-    )
-  }
-
-  if (!isAuthorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-  }
-
-  if (!process.env.DATABASE_URL) {
-    return NextResponse.json(
-      { error: "DATABASE_URL is required for snapshot refresh" },
-      { status: 500 }
-    )
-  }
-
-  try {
-    const requestedLimit = Number.parseInt(
-      new URL(request.url).searchParams.get("limit") ?? "",
-      10
-    )
-    const limit = Number.isFinite(requestedLimit)
-      ? Math.min(5000, Math.max(1, requestedLimit))
-      : 2000
-
-    const codes = await getCommunityPresetCodes(limit)
-    const source = request.headers.get("x-vercel-cron") === "1" ? "neon-cron" : "manual-refresh"
-    const snapshot = await writeCommunitySnapshot(codes, source, limit)
-
-    return NextResponse.json({
-      ok: true,
-      source: snapshot.source,
-      generatedAt: snapshot.generatedAt,
-      count: snapshot.codes.length,
-    })
-  } catch (error) {
-    console.error("Failed to refresh community snapshot", error)
-    return NextResponse.json(
-      { error: "Failed to refresh community snapshot" },
-      { status: 500 }
-    )
-  }
+  void request
+  return NextResponse.json(
+    {
+      error: "Community snapshot refresh moved to offline automation",
+      run: "pnpm --filter shadcnpreset refresh:community-snapshot -- 2000 manual-refresh",
+      docs: "apps/shadcnpreset/COMMUNITY_SNAPSHOT.md",
+    },
+    { status: 410 }
+  )
 }

--- a/apps/shadcnpreset/lib/community-snapshot.ts
+++ b/apps/shadcnpreset/lib/community-snapshot.ts
@@ -10,7 +10,6 @@ import { getPresetPage, type PresetPageItem } from "@/lib/preset-catalog"
 const DEFAULT_SNAPSHOT_LIMIT = 2000
 const FALLBACK_PAGE_SIZE = 100
 const SNAPSHOT_DATA_FILENAME = "community-presets-snapshot.json"
-const SNAPSHOT_ROW_ID = "default"
 const SNAPSHOT_MEMORY_CACHE_TTL_MS = 60_000
 
 const snapshotSchema = z.object({
@@ -20,6 +19,7 @@ const snapshotSchema = z.object({
 })
 
 type CommunitySnapshot = z.infer<typeof snapshotSchema>
+type CommunitySnapshotSource = "github-cron" | "manual-refresh" | "neon-cron"
 
 let inMemorySnapshotCache:
   | {
@@ -30,10 +30,6 @@ let inMemorySnapshotCache:
 
 function getSafeLimit(limit: number, max = DEFAULT_SNAPSHOT_LIMIT) {
   return Math.min(max, Math.max(1, limit))
-}
-
-function shouldSkipDbSnapshotRead() {
-  return process.env.NEXT_PHASE === "phase-production-build"
 }
 
 function normalizePresetCodes(codes: string[], limit: number) {
@@ -129,68 +125,20 @@ function loadSnapshotFromDataFile(): CommunitySnapshot | null {
   }
 }
 
-async function ensureSnapshotTable() {
-  const { query } = await import("@/lib/db")
-  await query(`
-    CREATE TABLE IF NOT EXISTS community_snapshot (
-      id TEXT PRIMARY KEY,
-      payload JSONB NOT NULL,
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-    );
-  `)
-}
-
-async function readSnapshotFromDb(): Promise<CommunitySnapshot | null> {
-  if (!process.env.DATABASE_URL) {
-    return null
-  }
-
-  try {
-    const { query } = await import("@/lib/db")
-    const result = await query<{ payload: CommunitySnapshot }>(
-      `
-      SELECT payload
-      FROM community_snapshot
-      WHERE id = $1
-      LIMIT 1
-      `,
-      [SNAPSHOT_ROW_ID]
-    )
-    const row = result.rows[0]
-    if (!row) return null
-
-    const parsed = snapshotSchema.safeParse(row.payload)
-    if (!parsed.success) return null
-    return parsed.data
-  } catch {
-    return null
-  }
-}
-
-async function getCachedDbSnapshot() {
+async function getCachedDataFileSnapshot() {
   "use cache"
   cacheLife({ stale: 3600, revalidate: 3600, expire: 86400 })
 
-  return readSnapshotFromDb()
+  return loadSnapshotFromDataFile()
 }
 
 async function readSnapshotPayload(): Promise<CommunitySnapshot | null> {
-  if (shouldSkipDbSnapshotRead()) {
-    return loadSnapshotFromDataFile()
-  }
-
   const fromMemory = readInMemorySnapshotCache()
   if (fromMemory?.codes.length) {
     return fromMemory
   }
 
-  const fromDb = await getCachedDbSnapshot()
-  if (fromDb?.codes.length) {
-    writeInMemorySnapshotCache(fromDb)
-    return fromDb
-  }
-
-  const fromDataFile = loadSnapshotFromDataFile()
+  const fromDataFile = await getCachedDataFileSnapshot()
   if (fromDataFile?.codes.length) {
     writeInMemorySnapshotCache(fromDataFile)
   }
@@ -218,9 +166,9 @@ export async function getCommunityCodesSnapshotFirst(
   return getDeterministicCommunityFallbackCodes(safeLimit)
 }
 
-export async function writeCommunitySnapshot(
+export function createCommunitySnapshot(
   codes: string[],
-  source: "neon-cron" | "manual-refresh" = "neon-cron",
+  source: CommunitySnapshotSource = "manual-refresh",
   limit = DEFAULT_SNAPSHOT_LIMIT
 ) {
   const normalized = normalizePresetCodes(codes, limit)
@@ -229,18 +177,6 @@ export async function writeCommunitySnapshot(
     source,
     codes: normalized,
   }
-
-  await ensureSnapshotTable()
-  const { query } = await import("@/lib/db")
-  await query(
-    `
-    INSERT INTO community_snapshot (id, payload, updated_at)
-    VALUES ($1, $2::jsonb, NOW())
-    ON CONFLICT (id) DO UPDATE
-    SET payload = EXCLUDED.payload, updated_at = NOW()
-    `,
-    [SNAPSHOT_ROW_ID, JSON.stringify(snapshot)]
-  )
 
   writeInMemorySnapshotCache(snapshot)
 

--- a/apps/shadcnpreset/scripts/refresh-community-snapshot.sh
+++ b/apps/shadcnpreset/scripts/refresh-community-snapshot.sh
@@ -2,62 +2,24 @@
 set -euo pipefail
 
 # Usage:
-#   CRON_SECRET="..." ./apps/shadcnpreset/scripts/refresh-community-snapshot.sh https://your-domain.com 2000
-#   BASE_URL="https://your-domain.com" CRON_SECRET="..." ./apps/shadcnpreset/scripts/refresh-community-snapshot.sh
+#   DATABASE_URL="postgres://..." ./apps/shadcnpreset/scripts/refresh-community-snapshot.sh
+#   DATABASE_URL="postgres://..." ./apps/shadcnpreset/scripts/refresh-community-snapshot.sh 2000 github-cron
 #
 # Notes:
-# - Arg1 or BASE_URL: deployment origin (no trailing slash needed)
-# - Arg2 (optional): limit, defaults to 2000
+# - Arg1 (optional): limit, defaults to 2000
+# - Arg2 (optional): source, defaults to manual-refresh
 
-# Optional inline fallback secret for local convenience.
-# WARNING: do not commit a real secret value.
-SCRIPT_CRON_SECRET=
-BASE_URL="https://shadcnpreset.com"
+LIMIT="${1:-${LIMIT:-2000}}"
+SOURCE="${2:-${SOURCE:-manual-refresh}}"
 
-BASE_URL="${1:-${BASE_URL:-}}"
-LIMIT="${2:-${LIMIT:-2000}}"
-
-if [[ -z "${BASE_URL}" ]]; then
-  echo "Provide BASE_URL as env var or first argument."
-  echo 'Example: BASE_URL="https://shadcnpreset.com" ./apps/shadcnpreset/scripts/refresh-community-snapshot.sh'
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required."
   exit 1
 fi
 
-BASE_URL="${BASE_URL%/}"
-ENDPOINT="${BASE_URL}/api/internal/community-snapshot/refresh?limit=${LIMIT}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${REPO_ROOT}"
 
-if [[ -z "${CRON_SECRET:-}" && -n "${SCRIPT_CRON_SECRET}" ]]; then
-  CRON_SECRET="${SCRIPT_CRON_SECRET}"
-fi
-
-if [[ -z "${CRON_SECRET:-}" ]]; then
-  read -r -s -p "Enter CRON_SECRET: " CRON_SECRET
-  echo
-fi
-
-if [[ -z "${CRON_SECRET}" ]]; then
-  echo "CRON_SECRET is required."
-  exit 1
-fi
-
-echo "Refreshing community snapshot..."
-echo "Endpoint: ${ENDPOINT}"
-
-HTTP_CODE="$(
-  curl -sS -o /tmp/community-snapshot-refresh-response.json \
-    -w "%{http_code}" \
-    -H "Authorization: Bearer ${CRON_SECRET}" \
-    "${ENDPOINT}"
-)"
-
-echo "Status: ${HTTP_CODE}"
-echo "Response:"
-cat /tmp/community-snapshot-refresh-response.json
-echo
-
-if [[ "${HTTP_CODE}" -lt 200 || "${HTTP_CODE}" -ge 300 ]]; then
-  echo "Refresh failed."
-  exit 1
-fi
-
-echo "Refresh succeeded."
+echo "Generating community snapshot JSON (limit=${LIMIT}, source=${SOURCE})..."
+pnpm --filter shadcnpreset refresh:community-snapshot -- "${LIMIT}" "${SOURCE}"
+echo "Updated apps/shadcnpreset/data/community-presets-snapshot.json"

--- a/apps/shadcnpreset/scripts/refresh-community-snapshot.ts
+++ b/apps/shadcnpreset/scripts/refresh-community-snapshot.ts
@@ -1,21 +1,26 @@
 import {
-  writeCommunitySnapshot,
+  createCommunitySnapshot,
   writeCommunitySnapshotToDataFile,
 } from "@/lib/community-snapshot"
 import { getCommunityPresetCodes } from "@/lib/community-presets"
 
 async function main() {
   const requestedLimit = Number.parseInt(process.argv[2] ?? "2000", 10)
+  const requestedSource = process.argv[3]
   const limit = Number.isFinite(requestedLimit)
     ? Math.min(5000, Math.max(1, requestedLimit))
     : 2000
+  const source =
+    requestedSource === "github-cron" || requestedSource === "manual-refresh"
+      ? requestedSource
+      : "manual-refresh"
 
   if (!process.env.DATABASE_URL) {
     throw new Error("DATABASE_URL is required")
   }
 
   const codes = await getCommunityPresetCodes(limit)
-  const snapshot = await writeCommunitySnapshot(codes, "manual-refresh", limit)
+  const snapshot = createCommunitySnapshot(codes, source, limit)
   writeCommunitySnapshotToDataFile(snapshot)
 
   console.log(

--- a/apps/shadcnpreset/vercel.json
+++ b/apps/shadcnpreset/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/internal/community-snapshot/refresh",
-      "schedule": "0 3 * * *"
-    }
-  ]
-}
+{}

--- a/turbo.json
+++ b/turbo.json
@@ -22,8 +22,7 @@
         "BETTER_AUTH_SECRET",
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
-        "OPENAI_API_KEY",
-        "CRON_SECRET"
+        "OPENAI_API_KEY"
       ],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },


### PR DESCRIPTION
Serve community snapshot data from the bundled JSON at runtime and shift refreshes to a scheduled GitHub workflow so community pages stop querying Neon for snapshot reads.