### PR TITLE
chore(shadcnpreset): refresh community snapshot data

### DIFF
--- a/apps/shadcnpreset/data/community-presets-snapshot.json
+++ b/apps/shadcnpreset/data/community-presets-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T05:33:57.445Z",
+  "generatedAt": "2026-07-19T05:43:35.674Z",
   "source": "github-cron",
   "codes": [
     "b4xFeBLg4O",
@@ -25,6 +25,7 @@
     "b1temXKTw",
     "b1tf3a6ES",
     "b2BVCNzPU",
+    "b2C8SzlTk",
     "b2D0wqNxT",
     "b2D2C45BY",
     "b2D2iPH7K",


### PR DESCRIPTION
Automated community snapshot refresh.

- Regenerated `apps/shadcnpreset/data/community-presets-snapshot.json`
- Source: scheduled GitHub Action