### PR TITLE
chore(shadcnpreset): refresh community snapshot data

### DIFF
--- a/apps/shadcnpreset/data/community-presets-snapshot.json
+++ b/apps/shadcnpreset/data/community-presets-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T05:42:13.012Z",
+  "generatedAt": "2026-07-22T05:41:06.574Z",
   "source": "github-cron",
   "codes": [
     "b4xFeBLg4O",
@@ -22,6 +22,7 @@
     "b1sAmEgbI",
     "b1skWYRbk",
     "b1tM0TSmQ",
+    "b1tel7tya",
     "b1temXKTw",
     "b1tf3a6ES",
     "b2BVCNzPU",
@@ -39,6 +40,7 @@
     "b3y3YilbtJ",
     "b43eDL5Kq",
     "b4NJfnXlq",
+    "b4OW5Y5IG",
     "b4aRK5K0fb",
     "b4hsK5y52",
     "b4hsK5zBI",


### PR DESCRIPTION
Automated community snapshot refresh.

- Regenerated `apps/shadcnpreset/data/community-presets-snapshot.json`
- Source: scheduled GitHub Action