### PR TITLE
chore(shadcnpreset): refresh community snapshot data

### DIFF
--- a/apps/shadcnpreset/data/community-presets-snapshot.json
+++ b/apps/shadcnpreset/data/community-presets-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-22T05:41:06.574Z",
+  "generatedAt": "2026-07-23T05:45:52.959Z",
   "source": "github-cron",
   "codes": [
     "b4xFeBLg4O",


### PR DESCRIPTION
Automated community snapshot refresh.

- Regenerated `apps/shadcnpreset/data/community-presets-snapshot.json`
- Source: scheduled GitHub Action